### PR TITLE
Force GHA ext-memcached to v3.2.0

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -3,6 +3,7 @@ name: CodeChecks
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -32,7 +32,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: :memcached, memcached-3.2.0
+          extensions: memcached
           coverage: xdebug
         env:
           fail-fast: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -34,6 +34,9 @@ jobs:
           extensions: memcached
           coverage: xdebug
 
+      - name: Memcached version
+        run: php -i | grep -A2 "memcached support"
+
       - name: Cache Composer packages
         id: composer-cache
         uses: actions/cache@v2

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -32,7 +32,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: memcached
+          extensions: memcached-3.2.0
           coverage: xdebug
 
       - name: Memcached version

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install required libraries for PECL ext-memcached
+        run: sudo apt-get install -y libmemcached-dev librdkafka-dev
+
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: memcached
+          extensions: memcached-3.2.0
           coverage: xdebug
         env:
           fail-fast: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -32,8 +32,10 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: memcached-3.2.0
+          extensions: :memcached, memcached-3.2.0
           coverage: xdebug
+        env:
+          fail-fast: true
 
       - name: Memcached version
         run: php -i | grep -A2 "memcached support"


### PR DESCRIPTION
Default ext-memcached version is 3.1.5, but 3.2.0 is required for PHP 8.0 support.
Until the base image is updated, install the required version from PECL.